### PR TITLE
Revert "Bump PHPs"

### DIFF
--- a/7.0/config.mk
+++ b/7.0/config.mk
@@ -1,1 +1,1 @@
-export PHP_VERSION=7.0.32
+export PHP_VERSION=7.0.31

--- a/7.1/config.mk
+++ b/7.1/config.mk
@@ -1,1 +1,1 @@
-export PHP_VERSION=7.1.24
+export PHP_VERSION=7.1.22

--- a/7.2/config.mk
+++ b/7.2/config.mk
@@ -1,1 +1,1 @@
-export PHP_VERSION=7.2.12
+export PHP_VERSION=7.2.10


### PR DESCRIPTION
This reverts commit ce3f69b4757cc97568709ba5663a9902d65aef6a.

It appears that MySQL 8 briefly worked with PHP, but this might have
been reverted in 7.2.12 (or 7.2.11). We'll want to investigate why so as
to not pin to an old version (this doesn't appear in the Changelog), but
for now, let's revert to 7.2.10.

---

cc @UserNotFound @fancyremarker 